### PR TITLE
File Descriptor Addition/Deletion

### DIFF
--- a/xivModdingFramework/Materials/DataContainers/XivMtrl.cs
+++ b/xivModdingFramework/Materials/DataContainers/XivMtrl.cs
@@ -102,14 +102,29 @@ namespace xivModdingFramework.Materials.DataContainers
         public List<int> TexturePathOffsetList { get; set; }
 
         /// <summary>
+        /// A list containing the Texture Path Unknowns
+        /// </summary>
+        public List<short> TexturePathUnknownList { get; set; }
+
+        /// <summary>
         /// A list containing the Map Path offsets
         /// </summary>
         public List<int> MapPathOffsetList { get; set; }
 
         /// <summary>
+        /// A list containing the Map Path Unknowns
+        /// </summary>
+        public List<short> MapPathUnknownList { get; set; }
+
+        /// <summary>
         /// A list containing the ColorSet Path offsets
         /// </summary>
         public List<int> ColorSetPathOffsetList { get; set; }
+
+        /// <summary>
+        /// A list containing the ColorSet Path Unknowns
+        /// </summary>
+        public List<short> ColorSetPathUnknownList { get; set; }
 
         /// <summary>
         /// A list containing the Texture Path strings

--- a/xivModdingFramework/Materials/FileTypes/Mtrl.cs
+++ b/xivModdingFramework/Materials/FileTypes/Mtrl.cs
@@ -162,10 +162,11 @@ namespace xivModdingFramework.Materials.FileTypes
 
                 // get the texture path offsets
                 xivMtrl.TexturePathOffsetList = new List<int>(xivMtrl.TextureCount);
+                xivMtrl.TexturePathUnknownList = new List<short>(xivMtrl.TextureCount);
                 for (var i = 0; i < xivMtrl.TextureCount; i++)
                 {
                     xivMtrl.TexturePathOffsetList.Add(br.ReadInt16());
-                    br.ReadBytes(2);
+                    xivMtrl.TexturePathUnknownList.Add(br.ReadInt16());
 
                     // add the size of the paths
                     if (i > 0)
@@ -176,10 +177,11 @@ namespace xivModdingFramework.Materials.FileTypes
 
                 // get the map path offsets
                 xivMtrl.MapPathOffsetList = new List<int>(xivMtrl.MapCount);
+                xivMtrl.MapPathUnknownList = new List<short>(xivMtrl.MapCount);
                 for (var i = 0; i < xivMtrl.MapCount; i++)
                 {
                     xivMtrl.MapPathOffsetList.Add(br.ReadInt16());
-                    br.ReadBytes(2);
+                    xivMtrl.MapPathUnknownList.Add(br.ReadInt16());
 
                     // add the size of the paths
                     if (i > 0)
@@ -194,10 +196,11 @@ namespace xivModdingFramework.Materials.FileTypes
 
                 // get the color set offsets
                 xivMtrl.ColorSetPathOffsetList = new List<int>(xivMtrl.ColorSetCount);
+                xivMtrl.ColorSetPathUnknownList = new List<short>(xivMtrl.ColorSetCount);
                 for (var i = 0; i < xivMtrl.ColorSetCount; i++)
                 {
                     xivMtrl.ColorSetPathOffsetList.Add(br.ReadInt16());
-                    br.ReadBytes(2);
+                    xivMtrl.ColorSetPathUnknownList.Add(br.ReadInt16());
 
                     // add the size of the paths
                     if (i > 0)
@@ -356,19 +359,22 @@ namespace xivModdingFramework.Materials.FileTypes
             mtrlBytes.Add(xivMtrl.ColorSetCount);
             mtrlBytes.Add(xivMtrl.Unknown1);
 
-            foreach (var texPath in xivMtrl.TexturePathOffsetList)
+            for (int i = 0; i < xivMtrl.TexturePathOffsetList.Count; i++)
             {
-                mtrlBytes.AddRange(BitConverter.GetBytes(texPath));
+                mtrlBytes.AddRange(BitConverter.GetBytes((short)xivMtrl.TexturePathOffsetList[i]));
+                mtrlBytes.AddRange(BitConverter.GetBytes((short)xivMtrl.TexturePathUnknownList[i]));
             }
 
-            foreach (var mapPath in xivMtrl.MapPathOffsetList)
+            for (int i = 0; i < xivMtrl.MapPathOffsetList.Count; i++)
             {
-                mtrlBytes.AddRange(BitConverter.GetBytes(mapPath));
+                mtrlBytes.AddRange(BitConverter.GetBytes((short)xivMtrl.MapPathOffsetList[i]));
+                mtrlBytes.AddRange(BitConverter.GetBytes((short)xivMtrl.MapPathUnknownList[i]));
             }
 
-            foreach (var colorPath in xivMtrl.ColorSetPathOffsetList)
+            for (int i = 0; i < xivMtrl.ColorSetPathOffsetList.Count; i++)
             {
-                mtrlBytes.AddRange(BitConverter.GetBytes(colorPath));
+                mtrlBytes.AddRange(BitConverter.GetBytes((short)xivMtrl.ColorSetPathOffsetList[i]));
+                mtrlBytes.AddRange(BitConverter.GetBytes((short)xivMtrl.ColorSetPathUnknownList[i]));
             }
 
             var pathStringList = new List<byte>();
@@ -394,7 +400,7 @@ namespace xivModdingFramework.Materials.FileTypes
             pathStringList.AddRange(Encoding.UTF8.GetBytes(xivMtrl.Shader));
             pathStringList.Add(0);
 
-            var paddingSize = xivMtrl.TexturePathsDataSize - pathStringList.Count;
+            var paddingSize = xivMtrl.MaterialDataSize - pathStringList.Count;
 
             pathStringList.AddRange(new byte[paddingSize]);
 


### PR DESCRIPTION
- Added File Descriptor Addition/Deletion
- Material Import/Export now carries through the unknown bits.

Deleting, then re-adding a file using the same path and offset should always result in identical Index/Index2 files.