### PR TITLE
Use cross-platform method, not hard-coded paths

### DIFF
--- a/xivModdingFramework/Helpers/ProblemChecker.cs
+++ b/xivModdingFramework/Helpers/ProblemChecker.cs
@@ -75,7 +75,7 @@ namespace xivModdingFramework.Helpers
 
                 for (var i = 0; i < largestDatNum; i++)
                 {
-                    var fileInfo = new FileInfo($"{_gameDirectory}\\{dataFile.GetDataFileName()}.win32.dat{i}");
+                    var fileInfo = new FileInfo(Path.Combine(_gameDirectory.FullName, $"{dataFile.GetDataFileName()}.win32.dat{i}"));
 
                     try
                     {
@@ -114,9 +114,9 @@ namespace xivModdingFramework.Helpers
             return Task.Run(() =>
             {
                 var backupDataFile =
-                    new DirectoryInfo($"{backupsDirectory.FullName}\\{dataFile.GetDataFileName()}.win32.index");
+                    new DirectoryInfo(Path.Combine(backupsDirectory.FullName, $"{dataFile.GetDataFileName()}.win32.index"));
                 var currentDataFile =
-                    new DirectoryInfo($"{_gameDirectory.FullName}\\{dataFile.GetDataFileName()}.win32.index");
+                    new DirectoryInfo(Path.Combine(_gameDirectory.FullName, $"{dataFile.GetDataFileName()}.win32.index"));
 
                 var backupHash = _index.GetIndexSection1Hash(backupDataFile);
                 var currentHash = _index.GetIndexSection1Hash(currentDataFile);

--- a/xivModdingFramework/Mods/FileTypes/TTMP.cs
+++ b/xivModdingFramework/Mods/FileTypes/TTMP.cs
@@ -141,16 +141,16 @@ namespace xivModdingFramework.Mods.FileTypes
 
                 File.WriteAllText(_tempMPL, JsonConvert.SerializeObject(modPackJson));
 
-                var modPackPath = $"{_modPackDirectory}\\{modPackData.Name}.ttmp2";
+                var modPackPath = Path.Combine(_modPackDirectory.FullName, $"{modPackData.Name}.ttmp2");
 
                 if (File.Exists(modPackPath))
                 {
                     var fileNum = 1;
-                    modPackPath = $"{_modPackDirectory}\\{modPackData.Name}({fileNum}).ttmp2";
+                    modPackPath = Path.Combine(_modPackDirectory.FullName, $"{modPackData.Name}({fileNum}).ttmp2");
                     while (File.Exists(modPackPath))
                     {
                         fileNum++;
-                        modPackPath = $"{_modPackDirectory}\\{modPackData.Name}({fileNum}).ttmp2";
+                        modPackPath = Path.Combine(_modPackDirectory.FullName, $"{modPackData.Name}({fileNum}).ttmp2");
                     }
                 }
 
@@ -239,16 +239,16 @@ namespace xivModdingFramework.Mods.FileTypes
 
                     File.WriteAllText(_tempMPL, JsonConvert.SerializeObject(modPackJson));
 
-                    var modPackPath = $"{_modPackDirectory}\\{modPackData.Name}.ttmp2";
+                    var modPackPath = Path.Combine(_modPackDirectory.FullName, $"{modPackData.Name}.ttmp2");
 
                     if (File.Exists(modPackPath))
                     {
                         var fileNum = 1;
-                        modPackPath = $"{_modPackDirectory}\\{modPackData.Name}({fileNum}).ttmp2";
+                        modPackPath = Path.Combine(_modPackDirectory.FullName, $"{modPackData.Name}({fileNum}).ttmp2");
                         while (File.Exists(modPackPath))
                         {
                             fileNum++;
-                            modPackPath = $"{_modPackDirectory}\\{modPackData.Name}({fileNum}).ttmp2";
+                            modPackPath = Path.Combine(_modPackDirectory.FullName, $"{modPackData.Name}({fileNum}).ttmp2");
                         }
                     }
 

--- a/xivModdingFramework/SqPack/FileTypes/Dat.cs
+++ b/xivModdingFramework/SqPack/FileTypes/Dat.cs
@@ -1022,7 +1022,7 @@ namespace xivModdingFramework.SqPack.FileTypes
             if (modEntry != null)
             {
                 datNum = ((modEntry.data.modOffset / 8) & 0x0F) / 2;
-                modDatPath = Path.Combine(_gameDirectory.FullName, $"{dataFile.GetDataFileName()}{DatExtension}{datNum}");
+                modDatPath = Path.Combine(_gameDirectory.FullName, $"{modEntry.datFile}{DatExtension}{datNum}");
 
                 if (!File.Exists(modDatPath))
                 {

--- a/xivModdingFramework/SqPack/FileTypes/Dat.cs
+++ b/xivModdingFramework/SqPack/FileTypes/Dat.cs
@@ -71,7 +71,7 @@ namespace xivModdingFramework.SqPack.FileTypes
                 return 8;
             }
 
-            var datPath = $"{_gameDirectory.FullName}\\{dataFile.GetDataFileName()}{DatExtension}{nextDatNumber}";
+            var datPath = Path.Combine(_gameDirectory.FullName, $"{dataFile.GetDataFileName()}{DatExtension}{nextDatNumber}");
 
             using (var fs = File.Create(datPath))
             {
@@ -301,7 +301,7 @@ namespace xivModdingFramework.SqPack.FileTypes
             // This formula is used to obtain the dat number in which the offset is located
             var datNum = ((offset / 8) & 0x0F) / 2;
 
-            var datPath = _gameDirectory + "\\" + dataFile.GetDataFileName() + DatExtension + datNum;
+            var datPath = Path.Combine(_gameDirectory.FullName, $"{dataFile.GetDataFileName()}{DatExtension}{datNum}");
 
             await _semaphoreSlim.WaitAsync();
 
@@ -545,7 +545,7 @@ namespace xivModdingFramework.SqPack.FileTypes
 
             offset = OffsetCorrection(datNum, offset);
 
-            var datPath = _gameDirectory + "\\" + dataFile.GetDataFileName() + DatExtension + datNum;
+            var datPath = Path.Combine(_gameDirectory.FullName, $"{dataFile.GetDataFileName()}{DatExtension}{datNum}");
 
             var byteList = new List<byte>();
             var meshCount = 0;
@@ -717,7 +717,7 @@ namespace xivModdingFramework.SqPack.FileTypes
             {
                 offset = OffsetCorrection(datNum, offset);
 
-                var datPath = _gameDirectory + "\\" + dataFile.GetDataFileName() + DatExtension + datNum;
+                var datPath = Path.Combine(_gameDirectory.FullName, $"{dataFile.GetDataFileName()}{DatExtension}{datNum}");
 
                 await Task.Run(async () =>
                 {
@@ -848,7 +848,7 @@ namespace xivModdingFramework.SqPack.FileTypes
 
             offset = OffsetCorrection(datNum, offset);
 
-            var datPath = $"{_gameDirectory}\\{dataFile.GetDataFileName()}{DatExtension}{datNum}";
+            var datPath = Path.Combine(_gameDirectory.FullName, $"{dataFile.GetDataFileName()}{DatExtension}{datNum}");
 
             if (File.Exists(datPath))
             {
@@ -873,7 +873,7 @@ namespace xivModdingFramework.SqPack.FileTypes
 
             offset = OffsetCorrection(datNum, offset);
 
-            var datPath = $"{_gameDirectory}\\{dataFile.GetDataFileName()}{DatExtension}{datNum}";
+            var datPath = Path.Combine(_gameDirectory.FullName, $"{dataFile.GetDataFileName()}{DatExtension}{datNum}");
 
             using (var br = new BinaryReader(File.OpenRead(datPath)))
             {
@@ -1011,7 +1011,7 @@ namespace xivModdingFramework.SqPack.FileTypes
 
             var datNum = GetLargestDatNumber(dataFile);
 
-            var modDatPath = $"{_gameDirectory}\\{dataFile.GetDataFileName()}{DatExtension}{datNum}";
+            var modDatPath = Path.Combine(_gameDirectory.FullName, $"{dataFile.GetDataFileName()}{DatExtension}{datNum}");
 
             if (category.Equals(itemName))
             {
@@ -1022,7 +1022,7 @@ namespace xivModdingFramework.SqPack.FileTypes
             if (modEntry != null)
             {
                 datNum = ((modEntry.data.modOffset / 8) & 0x0F) / 2;
-                modDatPath = $"{_gameDirectory}\\{modEntry.datFile}{DatExtension}{datNum}";
+                modDatPath = Path.Combine(_gameDirectory.FullName, $"{dataFile.GetDataFileName()}{DatExtension}{datNum}");
 
                 if (!File.Exists(modDatPath))
                 {
@@ -1040,7 +1040,7 @@ namespace xivModdingFramework.SqPack.FileTypes
                 {
                     datNum = CreateNewDat(dataFile);
 
-                    modDatPath = $"{_gameDirectory}\\{dataFile.GetDataFileName()}{DatExtension}{datNum}";
+                    modDatPath = Path.Combine(_gameDirectory.FullName, $"{dataFile.GetDataFileName()}{DatExtension}{datNum}");
                 }
                 else
                 {
@@ -1049,7 +1049,7 @@ namespace xivModdingFramework.SqPack.FileTypes
                     {
                         datNum = CreateNewDat(dataFile);
 
-                        modDatPath = $"{_gameDirectory}\\{dataFile.GetDataFileName()}{DatExtension}{datNum}";
+                        modDatPath = Path.Combine(_gameDirectory.FullName, $"{dataFile.GetDataFileName()}{DatExtension}{datNum}");
                     }
                 }
             }
@@ -1085,7 +1085,7 @@ namespace xivModdingFramework.SqPack.FileTypes
                     var sizeDiff = modEntry.data.modSize - importData.Count;
 
                     datNum = ((modEntry.data.modOffset / 8) & 0x0F) / 2;
-                    modDatPath = _gameDirectory + "\\" + modEntry.datFile + DatExtension + datNum;
+                    modDatPath = Path.Combine(_gameDirectory.FullName, $"{modEntry.datFile}{DatExtension}{datNum}");
                     var datOffsetAmount = 16 * datNum;
 
                     using (var bw = new BinaryWriter(File.OpenWrite(modDatPath)))
@@ -1145,7 +1145,7 @@ namespace xivModdingFramework.SqPack.FileTypes
                             var sizeDiff = emptyEntryLength - importData.Count;
 
                             datNum = ((mod.data.modOffset / 8) & 0x0F) / 2;
-                            modDatPath = _gameDirectory + "\\" + mod.datFile + DatExtension + datNum;
+                            modDatPath = Path.Combine(_gameDirectory.FullName, $"{mod.datFile}{DatExtension}{datNum}");
                             var datOffsetAmount = 16 * datNum;
 
                             using (var bw = new BinaryWriter(File.OpenWrite(modDatPath)))
@@ -1219,7 +1219,7 @@ namespace xivModdingFramework.SqPack.FileTypes
                     {
                         datNum = GetLargestDatNumber(dataFile);
 
-                        modDatPath = $"{_gameDirectory}\\{dataFile.GetDataFileName()}{DatExtension}{datNum}";
+                        modDatPath = Path.Combine(_gameDirectory.FullName, $"{dataFile.GetDataFileName()}{DatExtension}{datNum}");
 
                         fileLength = new FileInfo(modDatPath).Length;
 
@@ -1227,7 +1227,7 @@ namespace xivModdingFramework.SqPack.FileTypes
                         {
                             datNum = CreateNewDat(dataFile);
 
-                            modDatPath = $"{_gameDirectory}\\{dataFile.GetDataFileName()}{DatExtension}{datNum}";
+                            modDatPath = Path.Combine(_gameDirectory.FullName, $"{dataFile.GetDataFileName()}{DatExtension}{datNum}");
                         }
 
                         if (datNum >= 8)

--- a/xivModdingFramework/SqPack/FileTypes/Index.cs
+++ b/xivModdingFramework/SqPack/FileTypes/Index.cs
@@ -52,8 +52,8 @@ namespace xivModdingFramework.SqPack.FileTypes
 
             var indexPaths = new[]
             {
-                _gameDirectory + "\\" + dataFile.GetDataFileName() + IndexExtension,
-                _gameDirectory + "\\" + dataFile.GetDataFileName() + Index2Extension
+                Path.Combine(_gameDirectory.FullName, $"{dataFile.GetDataFileName()}{IndexExtension}"),
+                Path.Combine(_gameDirectory.FullName, $"{dataFile.GetDataFileName()}{Index2Extension}")
             };
 
             foreach (var indexPath in indexPaths)
@@ -76,8 +76,8 @@ namespace xivModdingFramework.SqPack.FileTypes
 
             var indexPaths = new[]
             {
-                _gameDirectory + "\\" + dataFile.GetDataFileName() + IndexExtension,
-                _gameDirectory + "\\" + dataFile.GetDataFileName() + Index2Extension
+                Path.Combine(_gameDirectory.FullName, $"{dataFile.GetDataFileName()}{IndexExtension}"),
+                Path.Combine(_gameDirectory.FullName, $"{dataFile.GetDataFileName()}{Index2Extension}")
             };
 
             for (var i = 0; i < indexPaths.Length; i++)
@@ -129,7 +129,7 @@ namespace xivModdingFramework.SqPack.FileTypes
         {
             return Task.Run(async () =>
             {
-                var indexPath = _gameDirectory + "\\" + dataFile.GetDataFileName() + IndexExtension;
+                var indexPath = Path.Combine(_gameDirectory.FullName, $"{dataFile.GetDataFileName()}{IndexExtension}");
                 var offset = 0;
 
                 // These are the offsets to relevant data
@@ -193,7 +193,7 @@ namespace xivModdingFramework.SqPack.FileTypes
             return Task.Run(() =>
             {
                 var fileDictionary = new Dictionary<string, int>();
-                var indexPath = _gameDirectory + "\\" + dataFile.GetDataFileName() + IndexExtension;
+                var indexPath = Path.Combine(_gameDirectory.FullName, $"{dataFile.GetDataFileName()}{IndexExtension}");
 
                 // These are the offsets to relevant data
                 const int fileCountOffset = 1036;
@@ -246,7 +246,7 @@ namespace xivModdingFramework.SqPack.FileTypes
                     const int fileCountOffset = 1036;
                     const int dataStartOffset = 2048;
 
-                    var indexPath = _gameDirectory + "\\" + dataFile.GetDataFileName() + IndexExtension;
+                    var indexPath = Path.Combine(_gameDirectory.FullName, $"{dataFile.GetDataFileName()}{IndexExtension}");
 
                     using (var br = new BinaryReader(File.OpenRead(indexPath)))
                     {
@@ -292,7 +292,7 @@ namespace xivModdingFramework.SqPack.FileTypes
         /// <returns>True if it exists, False otherwise</returns>
         public async Task<bool> FileExists(int fileHash, int folderHash, XivDataFile dataFile)
         {
-            var indexPath = _gameDirectory + "\\" + dataFile.GetDataFileName() + IndexExtension;
+            var indexPath = Path.Combine(_gameDirectory.FullName, $"{dataFile.GetDataFileName()}{IndexExtension}");
 
             // These are the offsets to relevant data
             const int fileCountOffset = 1036;
@@ -340,7 +340,7 @@ namespace xivModdingFramework.SqPack.FileTypes
         /// <returns>True if it exists, False otherwise</returns>
         public async Task<bool> FolderExists(int folderHash, XivDataFile dataFile)
         {
-            var indexPath = _gameDirectory + "\\" + dataFile.GetDataFileName() + IndexExtension;
+            var indexPath = Path.Combine(_gameDirectory.FullName, $"{dataFile.GetDataFileName()}{IndexExtension}");
 
             // These are the offsets to relevant data
             const int fileCountOffset = 1036;
@@ -387,7 +387,7 @@ namespace xivModdingFramework.SqPack.FileTypes
             const int fileCountOffset = 1036;
             const int dataStartOffset = 2048;
 
-            var indexPath = _gameDirectory + "\\" + dataFile.GetDataFileName() + IndexExtension;
+            var indexPath = Path.Combine(_gameDirectory.FullName, $"{dataFile.GetDataFileName()}{IndexExtension}");
 
             await Task.Run(() =>
             {
@@ -431,7 +431,7 @@ namespace xivModdingFramework.SqPack.FileTypes
             const int fileCountOffset = 1036;
             const int dataStartOffset = 2048;
 
-            var indexPath = _gameDirectory + "\\" + dataFile.GetDataFileName() + IndexExtension;
+            var indexPath = Path.Combine(_gameDirectory.FullName, $"{dataFile.GetDataFileName()}{IndexExtension}");
 
             await Task.Run(() =>
             {
@@ -471,7 +471,7 @@ namespace xivModdingFramework.SqPack.FileTypes
             const int fileCountOffset = 1036;
             const int dataStartOffset = 2048;
 
-            var indexPath = _gameDirectory + "\\" + dataFile.GetDataFileName() + IndexExtension;
+            var indexPath = Path.Combine(_gameDirectory.FullName, $"{dataFile.GetDataFileName()}{IndexExtension}");
 
             await Task.Run(() =>
             {
@@ -514,7 +514,7 @@ namespace xivModdingFramework.SqPack.FileTypes
             const int fileCountOffset = 1036;
             const int dataStartOffset = 2048;
 
-            var indexPath = _gameDirectory + "\\" + dataFile.GetDataFileName() + IndexExtension;
+            var indexPath = Path.Combine(_gameDirectory.FullName, $"{dataFile.GetDataFileName()}{IndexExtension}");
 
             await Task.Run(() =>
             {
@@ -574,7 +574,7 @@ namespace xivModdingFramework.SqPack.FileTypes
 
             // Index 1 Closure
             {
-                var indexPath = _gameDirectory + "\\" + dataFile.GetDataFileName() + IndexExtension;
+                var indexPath = Path.Combine(_gameDirectory.FullName, $"{dataFile.GetDataFileName()}{IndexExtension}");
 
                 // Dump the index into memory, since we're going to have to inject data.
                 byte[] originalIndex = File.ReadAllBytes(indexPath);
@@ -691,7 +691,7 @@ namespace xivModdingFramework.SqPack.FileTypes
 
             // Index 2 Closure
             {
-                var index2Path = _gameDirectory + "\\" + dataFile.GetDataFileName() + Index2Extension;
+                var index2Path = Path.Combine(_gameDirectory.FullName, $"{dataFile.GetDataFileName()}{Index2Extension}");
 
                 // Dump the index into memory, since we're going to have to inject data.
                 byte[] originalIndex = File.ReadAllBytes(index2Path);
@@ -817,7 +817,7 @@ namespace xivModdingFramework.SqPack.FileTypes
 
             // Index 1 Closure
             {
-                var indexPath = _gameDirectory + "\\" + dataFile.GetDataFileName() + IndexExtension;
+                var indexPath = Path.Combine(_gameDirectory.FullName, $"{dataFile.GetDataFileName()}{IndexExtension}");
 
                 // Dump the index into memory, since we're going to have to inject data.
                 byte[] originalIndex = File.ReadAllBytes(indexPath);
@@ -956,7 +956,7 @@ namespace xivModdingFramework.SqPack.FileTypes
 
             // Index 2 Closure
             {
-                var index2Path = _gameDirectory + "\\" + dataFile.GetDataFileName() + Index2Extension;
+                var index2Path = Path.Combine(_gameDirectory.FullName, $"{dataFile.GetDataFileName()}{Index2Extension}");
 
                 // Dump the index into memory, since we're going to have to inject data.
                 byte[] originalIndex = File.ReadAllBytes(index2Path);
@@ -1064,7 +1064,7 @@ namespace xivModdingFramework.SqPack.FileTypes
             const int fileCountOffset = 1036;
             const int dataStartOffset = 2048;
 
-            var indexPath = _gameDirectory + "\\" + dataFile.GetDataFileName() + IndexExtension;
+            var indexPath = Path.Combine(_gameDirectory.FullName, $"{dataFile.GetDataFileName()}{IndexExtension}");
 
             await Task.Run(() =>
             {
@@ -1125,7 +1125,7 @@ namespace xivModdingFramework.SqPack.FileTypes
             const int fileCountOffset = 1036;
             const int dataStartOffset = 2048;
 
-            var index2Path = _gameDirectory + "\\" + dataFile.GetDataFileName() + Index2Extension;
+            var index2Path = Path.Combine(_gameDirectory.FullName, $"{dataFile.GetDataFileName()}{Index2Extension}");
 
             await Task.Run(() =>
             {
@@ -1168,11 +1168,11 @@ namespace xivModdingFramework.SqPack.FileTypes
         {
             var fileName = dataFile.GetDataFileName();
 
-            var indexPath = _gameDirectory + "\\" + fileName + IndexExtension;
-            var index2Path = _gameDirectory + "\\" + fileName + Index2Extension;
+            var indexPath = Path.Combine(_gameDirectory.FullName, $"{fileName}{IndexExtension}");
+            var index2Path = Path.Combine(_gameDirectory.FullName, $"{fileName}{Index2Extension}");
 
-            var indexBackupPath = backupsDirectory.FullName + "\\" + fileName + IndexExtension;
-            var index2BackupPath = backupsDirectory.FullName + "\\" + fileName + Index2Extension;
+            var indexBackupPath = Path.Combine(backupsDirectory.FullName, $"{fileName}{IndexExtension}");
+            var index2BackupPath = Path.Combine(backupsDirectory.FullName, $"{fileName}{Index2Extension}");
 
             Directory.CreateDirectory(backupsDirectory.FullName);
 
@@ -1205,8 +1205,8 @@ namespace xivModdingFramework.SqPack.FileTypes
             var fileName = dataFile.GetDataFileName();
             var isLocked = false;
 
-            var indexPath = $"{_gameDirectory}\\{fileName}{IndexExtension}";
-            var index2Path = $"{_gameDirectory}\\{fileName}{Index2Extension}";
+            var indexPath = Path.Combine(_gameDirectory.FullName, $"{fileName}{IndexExtension}");
+            var index2Path = Path.Combine(_gameDirectory.FullName, $"{fileName}{IndexExtension}");
 
             FileStream stream = null;
             FileStream stream1 = null;

--- a/xivModdingFramework/SqPack/FileTypes/Index.cs
+++ b/xivModdingFramework/SqPack/FileTypes/Index.cs
@@ -1206,7 +1206,7 @@ namespace xivModdingFramework.SqPack.FileTypes
             var isLocked = false;
 
             var indexPath = Path.Combine(_gameDirectory.FullName, $"{fileName}{IndexExtension}");
-            var index2Path = Path.Combine(_gameDirectory.FullName, $"{fileName}{IndexExtension}");
+            var index2Path = Path.Combine(_gameDirectory.FullName, $"{fileName}{Index2Extension}");
 
             FileStream stream = null;
             FileStream stream1 = null;


### PR DESCRIPTION
These changes are made in an effort to make the xivmoddingframework more cross-platform friendly. The first roadblock I found was hard-coded paths, which is addressed here.