### PR TITLE
Vertex Color/Alpha Data Order Changed to match 1.9.9.3 Functionality

### DIFF
--- a/xivModdingFramework/Models/FileTypes/Mdl.cs
+++ b/xivModdingFramework/Models/FileTypes/Mdl.cs
@@ -1044,10 +1044,10 @@ namespace xivModdingFramework.Models.FileTypes
 
                                 br.BaseStream.Seek(colorOffset, SeekOrigin.Begin);
 
-                                var a = br.ReadByte();
                                 var r = br.ReadByte();
                                 var g = br.ReadByte();
                                 var b = br.ReadByte();
+                                var a = br.ReadByte();
 
                                 vertexData.Colors.Add(new Color(r, g, b, a));
                                 vertexData.Colors4.Add(new Color4((r / 255f), (g / 255f), (b / 255f), (a / 255f)));
@@ -4919,14 +4919,14 @@ namespace xivModdingFramework.Models.FileTypes
                             alpha = Convert.ToByte(Math.Round(colladaMeshData.VertexAlphas[i] * 255));
                         }
 
-                        if (!flipAlpha)
+                        if (flipAlpha)
                         {
                             importData.VertexData1.Add(alpha);
                         }
                         importData.VertexData1.Add(red);
                         importData.VertexData1.Add(green);
                         importData.VertexData1.Add(blue);
-                        if (flipAlpha)
+                        if (!flipAlpha)
                         {
                             importData.VertexData1.Add(alpha);
                         }


### PR DESCRIPTION
Vertex Color/Alpha byte order changed to RGBA from ARGB to match 1.9.9.3 functionality.
FlipAlpha import variable inverted to go along with the change.