### PR TITLE
Add exception for when mesh number can't be read

### DIFF
--- a/xivModdingFramework/Models/FileTypes/Dae.cs
+++ b/xivModdingFramework/Models/FileTypes/Dae.cs
@@ -1041,16 +1041,26 @@ namespace xivModdingFramework.Models.FileTypes
 
                             meshNameDict.Add(id, atr);
 
-                            var meshNum = int.Parse(atr.Substring(atr.LastIndexOf("_", StringComparison.Ordinal) + 1, 1));
+                            var meshNum = 0;
 
-                            // Determines whether the mesh has parts and gets the mesh number
-                            if (atr.Contains("."))
+                            try
                             {
-                                meshNum = int.Parse(atr.Substring(atr.LastIndexOf("_", StringComparison.Ordinal) + 1,
-                                    atr.LastIndexOf(".", StringComparison.Ordinal) -
-                                    (atr.LastIndexOf("_", StringComparison.Ordinal) + 1)));
-                            }
+                                meshNum = int.Parse(atr.Substring(atr.LastIndexOf("_", StringComparison.Ordinal) + 1, 1));
 
+                                // Determines whether the mesh has parts and gets the mesh number
+                                if (atr.Contains("."))
+                                {
+                                    meshNum = int.Parse(atr.Substring(atr.LastIndexOf("_", StringComparison.Ordinal) + 1,
+                                        atr.LastIndexOf(".", StringComparison.Ordinal) -
+                                        (atr.LastIndexOf("_", StringComparison.Ordinal) + 1)));
+                                }
+                            }
+                            catch
+                            {
+                                throw new Exception($"Could not read mesh number of mesh: {atr}\n\n" +
+                                                    $"Please make sure your mesh name ends with the mesh/part number.");
+                            }
+                        
                             // If the current attribute is a mesh part
                             if (atr.Contains("."))
                             {

--- a/xivModdingFramework/Models/FileTypes/Dae.cs
+++ b/xivModdingFramework/Models/FileTypes/Dae.cs
@@ -477,14 +477,24 @@ namespace xivModdingFramework.Models.FileTypes
 
                             meshNameDict.Add(id, atr);
 
-                            var meshNum = int.Parse(atr.Substring(atr.LastIndexOf("_", StringComparison.Ordinal) + 1, 1));
+                            var meshNum = 0;
 
-                            // Determines whether the mesh has parts and gets the mesh number
-                            if (atr.Contains("."))
+                            try
                             {
-                                meshNum = int.Parse(atr.Substring(atr.LastIndexOf("_", StringComparison.Ordinal) + 1,
-                                    atr.LastIndexOf(".", StringComparison.Ordinal) -
-                                    (atr.LastIndexOf("_", StringComparison.Ordinal) + 1)));
+                                meshNum = int.Parse(atr.Substring(atr.LastIndexOf("_", StringComparison.Ordinal) + 1, 1));
+
+                                // Determines whether the mesh has parts and gets the mesh number
+                                if (atr.Contains("."))
+                                {
+                                    meshNum = int.Parse(atr.Substring(atr.LastIndexOf("_", StringComparison.Ordinal) + 1,
+                                        atr.LastIndexOf(".", StringComparison.Ordinal) -
+                                        (atr.LastIndexOf("_", StringComparison.Ordinal) + 1)));
+                                }
+                            }
+                            catch
+                            {
+                                throw new Exception($"Could not read mesh number of mesh: {atr}\n\n" +
+                                                    $"Please make sure your mesh name ends with the mesh/part number.");
                             }
 
                             while (reader.Read())
@@ -692,8 +702,17 @@ namespace xivModdingFramework.Models.FileTypes
                             // If the current attribute is a mesh part
                             if (atr.Contains("."))
                             {
-                                // Get part number
-                                var meshPartNum = int.Parse(atr.Substring(atr.LastIndexOf(".") + 1));
+                                var meshPartNum = 0;
+                                try
+                                {
+                                    // Get part number
+                                    meshPartNum = int.Parse(atr.Substring(atr.LastIndexOf(".") + 1));
+                                }
+                                catch
+                                {
+                                    throw new Exception($"Could not read mesh number of mesh: {atr}\n\n" +
+                                                    $"Please make sure your mesh name ends with the mesh/part number.");
+                                }                                
 
                                 if (!meshPartDataDictionary.ContainsKey(meshNum))
                                 {

--- a/xivModdingFramework/Models/FileTypes/Dae.cs
+++ b/xivModdingFramework/Models/FileTypes/Dae.cs
@@ -1064,10 +1064,19 @@ namespace xivModdingFramework.Models.FileTypes
                             // If the current attribute is a mesh part
                             if (atr.Contains("."))
                             {
-                                // Get part number
-                                var numStr = atr.Substring(atr.LastIndexOf(".") + 1);
-                                numStr = numStr.EndsWith("Mesh", StringComparison.OrdinalIgnoreCase) ? numStr.Remove(numStr.Length - 4):numStr;
-                                var meshPartNum = int.Parse(numStr);
+                                var meshPartNum = 0;
+                                try
+                                {
+                                    // Get part number
+                                    var numStr = atr.Substring(atr.LastIndexOf(".") + 1);
+                                    numStr = numStr.EndsWith("Mesh", StringComparison.OrdinalIgnoreCase) ? numStr.Remove(numStr.Length - 4):numStr;
+                                    meshPartNum = int.Parse(numStr);
+                                }
+                                catch
+                                {
+                                    throw new Exception($"Could not read mesh number of mesh: {atr}\n\n" +
+                                                        $"Please make sure your mesh name ends with the mesh/part number.");
+                                }                            
 
                                 if (meshPartDictionary.ContainsKey(meshNum))
                                 {


### PR DESCRIPTION
Currently when a user tries to import a DAE containing an invalid mesh name such as:

- mesh_name_1_Copy
- mesh_name

The exception that gets thrown is the generic Parse exception which doesn't provide much context:
![2020-01-03 at 18 31 54](https://user-images.githubusercontent.com/59175928/71739227-21aa5700-2e59-11ea-87be-224ab7dfb273.png)
![2020-01-03 at 18 32 43](https://user-images.githubusercontent.com/59175928/71739234-240cb100-2e59-11ea-9c0b-2c51b439b7dd.png)

I've added a simple try catch to give the user feedback on what mesh exactly caused the issue. This hopefully leads to less confusion and questions on the TT discord.

Example of new error:
![2020-01-03 at 18 47 05](https://user-images.githubusercontent.com/59175928/71739360-7b128600-2e59-11ea-882a-a6eed4f30019.png)

