### PR TITLE
Fix colourset import of undyeable items onto dyeable items

### DIFF
--- a/xivModdingFramework/Materials/FileTypes/Mtrl.cs
+++ b/xivModdingFramework/Materials/FileTypes/Mtrl.cs
@@ -382,7 +382,7 @@ namespace xivModdingFramework.Materials.FileTypes
                         xivMtrl.Unknown2 = br.ReadBytes(xivMtrl.UnknownDataSize);
 
                         xivMtrl.ColorSetData = new List<Half>();
-                        xivMtrl.ColorSetExtraData = new byte[0];
+                        xivMtrl.ColorSetExtraData = null;
                         if (xivMtrl.ColorSetDataSize > 0)
                         {
                             // Color Data is always 512 (6 x 14 = 64 x 8bpp = 512)

--- a/xivModdingFramework/Textures/FileTypes/Tex.cs
+++ b/xivModdingFramework/Textures/FileTypes/Tex.cs
@@ -954,6 +954,11 @@ namespace xivModdingFramework.Textures.FileTypes
                     // This reads 16 ushort values which is 16 x 2 = 32
                     colorSetExtraData = File.ReadAllBytes(flagsPath);
                 }
+                else
+                {                    
+                    // If .dat file is missing set all values to 0 (undyeable)
+                    colorSetExtraData = new byte[32];
+                }
             }
 
             // Replace the color set data with the imported data

--- a/xivModdingFramework/Textures/FileTypes/Tex.cs
+++ b/xivModdingFramework/Textures/FileTypes/Tex.cs
@@ -953,9 +953,16 @@ namespace xivModdingFramework.Textures.FileTypes
                     // The extra data after the colorset is always 32 bytes 
                     // This reads 16 ushort values which is 16 x 2 = 32
                     colorSetExtraData = File.ReadAllBytes(flagsPath);
+                    
+                    // If for whatever reason there is a .dat file but it's missing data
+                    if ( colorSetExtraData.Length != 32)
+                    {
+                        // Set all dye modifiers to 0 (undyeable)
+                        colorSetExtraData = new byte[32];
+                    }
                 }
                 else
-                {                    
+                {
                     // If .dat file is missing set all values to 0 (undyeable)
                     colorSetExtraData = new byte[32];
                 }


### PR DESCRIPTION
Due to the ColorSetExtraData getting set to a single 0 byte at line 385 of Mtrl.cs a .dat file was getting exported even for undyeable items. This .dat file didn't contain anything so when it was getting read at line 55 of Tex.cs instead of 32 bytes of data only a single byte was returned. As a result later an offset was incorrect resulting in the binary reader trying to read out of bounds. Textools continuously crashes after this failed import and an empty colourset could be seen in the modlist. 

Initial error upon attempting to import:
![br crash](https://user-images.githubusercontent.com/59175928/71784071-649e3300-2fef-11ea-8ab4-245fb97c5ebc.png)
Error upon opening the modlist:
![modlist error](https://user-images.githubusercontent.com/59175928/71784082-84355b80-2fef-11ea-948d-100238ac01b5.png)
Corrupted colourset entry in modlist:
![corrupted colourset](https://user-images.githubusercontent.com/59175928/71784105-e55d2f00-2fef-11ea-9f45-9d345e1d31c2.png)

To reproduce:

1. Export a colourset DDS of an item that cannot be dyed.
2. Verify that a .dat file was also exported containing 0 bytes.
3. Import this onto an item that can be dyed.
4. Textools crashes with an error as shown above.

My solution:
Initialize ColorsetExtraData as null so no unnecessary .dat file is generated. Then upon import if there is a .dat file but it does not contain 32 bytes as expected then replace the data with 32 bytes with a value of 0. If the .dat file is missing altogether then add the expected 32 bytes with a value of 0. 


