### PR TITLE
Speed up of mod import process

### DIFF
--- a/xivModdingFramework/Mods/FileTypes/TTMP.cs
+++ b/xivModdingFramework/Mods/FileTypes/TTMP.cs
@@ -444,7 +444,7 @@ namespace xivModdingFramework.Mods.FileTypes
                                                         modJson.FullPath,
                                                         modJson.Category.GetDisplayName(), modJson.Name,
                                                         XivDataFiles.GetXivDataFile(modJson.DatFile), _source,
-                                                        GetDataType(modJson.FullPath), modJson.ModPackEntry);
+                                                        GetDataType(modJson.FullPath), modJson.ModPackEntry, false);
                                                 }
                                                 else
                                                 {
@@ -455,7 +455,7 @@ namespace xivModdingFramework.Mods.FileTypes
                                                     await dat.WriteToDat(new List<byte>(data), null, modJson.FullPath,
                                                         modJson.Category.GetDisplayName(), modJson.Name,
                                                         XivDataFiles.GetXivDataFile(modJson.DatFile), _source,
-                                                        GetDataType(modJson.FullPath), modJson.ModPackEntry);
+                                                        GetDataType(modJson.FullPath), modJson.ModPackEntry, false);
                                                 }
                                             }
                                             catch (Exception ex)
@@ -474,6 +474,8 @@ namespace xivModdingFramework.Mods.FileTypes
 
                                             modCount++;
                                         }
+
+                                        dat.WriteModList();
                                     }
                                 }
                             }


### PR DESCRIPTION
ModList is now memory cached, and should be written at the end of file import. This speeds up the import of large number of files a lot. Should be merged at the same time as the PR for main module.