### PR TITLE
Added check of DDS type when importing colourset

### DIFF
--- a/xivModdingFramework/Textures/FileTypes/Tex.cs
+++ b/xivModdingFramework/Textures/FileTypes/Tex.cs
@@ -932,7 +932,27 @@ namespace xivModdingFramework.Textures.FileTypes
 
             using (var br = new BinaryReader(File.OpenRead(ddsFileDirectory.FullName)))
             {
-                // skip DDS header
+                // Check DDS type
+                br.BaseStream.Seek(84, SeekOrigin.Begin);
+
+                var texType = br.ReadInt32();
+                XivTexFormat textureType;
+
+                if (DDSType.ContainsKey(texType))
+                {
+                    textureType = DDSType[texType];
+                }
+                else
+                {
+                    throw new Exception($"DDS Type ({texType}) not recognized. Expecting A16B16G16R16F.");
+                }
+
+                if (textureType != XivTexFormat.A16B16G16R16F)
+                {
+                    throw new Exception($"Incorrect file type. Expected: A16B16G16R16F  Given: {textureType}");
+                }
+
+                // Skip past rest of the DDS header
                 br.BaseStream.Seek(128, SeekOrigin.Begin);
 
                 // color data is always 512 (4w x 16h = 64 x 8bpp = 512)


### PR DESCRIPTION
If for whatever reason a user decides to use something other than the colourset editor, saves it in the wrong format and then tries to import it into TexTools three binary stream errors appear and TexTools crashes. 

The initial error:
![2020-01-08 at 00 14 58](https://user-images.githubusercontent.com/59175928/71937262-2a2dc500-31ac-11ea-8af6-9bc1c31a9992.png)

To combat this I've mostly copied over the DDS type check already present in the other importer so that the user gets feedback about what caused the error and TexTools no longer crashes.

Relevant other PR: https://github.com/liinko/FFXIV_TexTools_UI/pull/20