### PR TITLE
Disable mod toggle for matadded textures

### DIFF
--- a/xivModdingFramework/Mods/Enums/XivModStatus.cs
+++ b/xivModdingFramework/Mods/Enums/XivModStatus.cs
@@ -19,6 +19,7 @@ namespace xivModdingFramework.Mods.Enums
     public enum XivModStatus
     {
         Original,
+        MatAdd,
         Enabled,
         Disabled
     }

--- a/xivModdingFramework/Mods/Modding.cs
+++ b/xivModdingFramework/Mods/Modding.cs
@@ -163,6 +163,12 @@ namespace xivModdingFramework.Mods
                 {
                     return XivModStatus.Original;
                 }
+                // If modEntry not null but modded offset and original offset are the same as is the case with matadd textures
+                if (modEntry.data.modOffset == modEntry.data.originalOffset)
+                {
+                    // Return original to disable the disable/enable button as there's nothing to toggle between
+                    return XivModStatus.Original;
+                }
 
                 return modEntry.enabled ? XivModStatus.Enabled : XivModStatus.Disabled;
             }
@@ -187,6 +193,12 @@ namespace xivModdingFramework.Mods
             if (modEntry == null)
             {
                 throw new Exception("Unable to find mod entry in modlist.");
+            }
+
+            // Matadd textures have the same mod offset as original so nothing to toggle
+            if (modEntry.data.originalOffset == modEntry.data.modOffset)
+            {
+                return;
             }
 
             if (enable)
@@ -247,7 +259,9 @@ namespace xivModdingFramework.Mods
 
             foreach (var modEntry in mods)
             {
-                if(modEntry.name.Equals(string.Empty)) continue;
+                if (modEntry.name.Equals(string.Empty)) continue;
+                // Matadd textures have the same mod offset as original so nothing to toggle
+                if (modEntry.data.modOffset == modEntry.data.originalOffset) continue;
 
                 if (enable)
                 {
@@ -283,7 +297,9 @@ namespace xivModdingFramework.Mods
             {
                 if(string.IsNullOrEmpty(modEntry.name)) continue;
                 if(string.IsNullOrEmpty(modEntry.fullPath)) continue;
-                
+                // Matadd textures have the same mod offset as original so nothing to toggle
+                if (modEntry.data.modOffset == modEntry.data.originalOffset) continue;
+
                 if (enable && !modEntry.enabled)
                 {
                     await index.UpdateIndex(modEntry.data.modOffset, modEntry.fullPath, XivDataFiles.GetXivDataFile(modEntry.datFile));

--- a/xivModdingFramework/Mods/Modding.cs
+++ b/xivModdingFramework/Mods/Modding.cs
@@ -167,7 +167,7 @@ namespace xivModdingFramework.Mods
                 if (modEntry.data.modOffset == modEntry.data.originalOffset)
                 {
                     // Return original to disable the disable/enable button as there's nothing to toggle between
-                    return XivModStatus.Original;
+                    return XivModStatus.MatAdd;
                 }
 
                 return modEntry.enabled ? XivModStatus.Enabled : XivModStatus.Disabled;


### PR DESCRIPTION
**The issue:**
It is possible for TexTools to crash if you misclick and disable a texture right after adding a new material. Textures added to an item through material addition end up with their mod offset being the same as their original offset. As a result of this toggling these mods has no real effect as it simply sets the indices to the same offset, but it still calls a bunch of other functions in the process.

**My solution:**
I've added checks so that if the modOffset and originalOffset of a modded item is the same, the toggle button gets disabled. This prevents misclicks leading to crashes and unnecessary execution of code.

This PR should be merged together with https://github.com/liinko/FFXIV_TexTools_UI/pull/21