### PR TITLE
Fixed empty line in skel files causing skeleton errors

### DIFF
--- a/xivModdingFramework/Models/FileTypes/Dae.cs
+++ b/xivModdingFramework/Models/FileTypes/Dae.cs
@@ -137,6 +137,7 @@ namespace xivModdingFramework.Models.FileTypes
                 // Deserializes the json skeleton file and makes 2 dictionaries with names and numbers as keys
                 foreach (var b in skeletonData)
                 {
+                    if (b == "") continue;
                     var j = JsonConvert.DeserializeObject<SkeletonData>(b);
 
                     FullSkel.Add(j.BoneName, j);

--- a/xivModdingFramework/Models/FileTypes/Sklb.cs
+++ b/xivModdingFramework/Models/FileTypes/Sklb.cs
@@ -440,6 +440,7 @@ namespace xivModdingFramework.Models.FileTypes
 
                 foreach (var b in skeletonData)
                 {
+                    if (b == "") continue;
                     var j = JsonConvert.DeserializeObject<SkeletonData>(b);
 
                     raceSkeletonData.Add(j);
@@ -472,7 +473,7 @@ namespace xivModdingFramework.Models.FileTypes
                         bone.BoneParent = raceMatchBone.BoneNumber;
 
                         raceSkeletonData.Add(bone);
-                        File.AppendAllText(skelLoc + race + ".skel", JsonConvert.SerializeObject(bone) + Environment.NewLine);
+                        File.AppendAllText(skelLoc + race + ".skel", Environment.NewLine + JsonConvert.SerializeObject(bone));
                     }
                 }
             }

--- a/xivModdingFramework/Models/FileTypes/Sklb.cs
+++ b/xivModdingFramework/Models/FileTypes/Sklb.cs
@@ -472,7 +472,7 @@ namespace xivModdingFramework.Models.FileTypes
                         bone.BoneParent = raceMatchBone.BoneNumber;
 
                         raceSkeletonData.Add(bone);
-                        File.AppendAllText(skelLoc + race + ".skel", Environment.NewLine + JsonConvert.SerializeObject(bone));
+                        File.AppendAllText(skelLoc + race + ".skel", JsonConvert.SerializeObject(bone) + Environment.NewLine);
                     }
                 }
             }


### PR DESCRIPTION
When a skeleton file gets generated for the first time it already ends on a new line. This causes an empty line to appear when the skeleton file gets appended upon exporting a head, face or hair. This empty line then causes errors when the json gets deserialized resulting in an empty element.

How to reproduce:
1. Delete your existing c0201.skel file in the Skeletons folder.
2. Export the female midlander model of a body equipment item for example the Adept's Gown
3. Try to export the number 1 face of the female midlander

You'll see the following error:
![image](https://user-images.githubusercontent.com/59175928/72941705-f9d05400-3d71-11ea-95d5-915be64eb41b.png)

In reality this is a very minor problem since nobody should ever be deleting their skel files, but either way it's a small bug.