### PR TITLE
Option to overwrite existing ModPack

### DIFF
--- a/xivModdingFramework/Mods/FileTypes/TTMP.cs
+++ b/xivModdingFramework/Mods/FileTypes/TTMP.cs
@@ -48,7 +48,7 @@ namespace xivModdingFramework.Mods.FileTypes
         /// <param name="modPackData">The data that will go into the mod pack</param>
         /// <param name="progress">The progress of the mod pack creation</param>
         /// <returns>The number of pages created for the mod pack</returns>
-        public async Task<int> CreateWizardModPack(ModPackData modPackData, IProgress<double> progress)
+        public async Task<int> CreateWizardModPack(ModPackData modPackData, IProgress<double> progress, bool overwriteModpack)
         {
             var processCount = await Task.Run<int>(() =>
             {
@@ -144,7 +144,7 @@ namespace xivModdingFramework.Mods.FileTypes
 
                 var modPackPath = Path.Combine(_modPackDirectory.FullName, $"{modPackData.Name}.ttmp2");
 
-                if (File.Exists(modPackPath))
+                if (File.Exists(modPackPath) && !overwriteModpack)
                 {
                     var fileNum = 1;
                     modPackPath = Path.Combine(_modPackDirectory.FullName, $"{modPackData.Name}({fileNum}).ttmp2");
@@ -153,6 +153,10 @@ namespace xivModdingFramework.Mods.FileTypes
                         fileNum++;
                         modPackPath = Path.Combine(_modPackDirectory.FullName, $"{modPackData.Name}({fileNum}).ttmp2");
                     }
+                }
+                else if (File.Exists(modPackPath) && overwriteModpack)
+                {
+                    File.Delete(modPackPath);
                 }
 
                 using (var zip = ZipFile.Open(modPackPath, ZipArchiveMode.Create))

--- a/xivModdingFramework/Mods/FileTypes/TTMP.cs
+++ b/xivModdingFramework/Mods/FileTypes/TTMP.cs
@@ -181,7 +181,7 @@ namespace xivModdingFramework.Mods.FileTypes
         /// <param name="gameDirectory">The game directory</param>
         /// <param name="progress">The progress of the mod pack creation</param>
         /// <returns>The number of mods processed for the mod pack</returns>
-        public async Task<int> CreateSimpleModPack(SimpleModPackData modPackData, DirectoryInfo gameDirectory, IProgress<(int current, int total, string message)> progress)
+        public async Task<int> CreateSimpleModPack(SimpleModPackData modPackData, DirectoryInfo gameDirectory, IProgress<(int current, int total, string message)> progress, bool overwriteModpack)
         {
             var processCount = await Task.Run<int>(() =>
             {
@@ -242,7 +242,7 @@ namespace xivModdingFramework.Mods.FileTypes
 
                     var modPackPath = Path.Combine(_modPackDirectory.FullName, $"{modPackData.Name}.ttmp2");
 
-                    if (File.Exists(modPackPath))
+                    if (File.Exists(modPackPath) && !overwriteModpack)
                     {
                         var fileNum = 1;
                         modPackPath = Path.Combine(_modPackDirectory.FullName, $"{modPackData.Name}({fileNum}).ttmp2");
@@ -251,6 +251,10 @@ namespace xivModdingFramework.Mods.FileTypes
                             fileNum++;
                             modPackPath = Path.Combine(_modPackDirectory.FullName, $"{modPackData.Name}({fileNum}).ttmp2");
                         }
+                    }
+                    else if (File.Exists(modPackPath) && overwriteModpack)
+                    {
+                        File.Delete(modPackPath);
                     }
 
                     using (var zip = ZipFile.Open(modPackPath, ZipArchiveMode.Create))


### PR DESCRIPTION
If a mod pack with the same name already exists, TexTools defaults to renaming the modpack. I've added a dialog to give the user the choice to overwrite the existing modpack, rename the modpack automatically or go back to the modpack creator to manually give it a new name.

![image](https://user-images.githubusercontent.com/59175928/73120602-d293a580-3f70-11ea-9c49-970e569536fe.png)


Should be merged together with: https://github.com/liinko/FFXIV_TexTools_UI/pull/27