### PR TITLE
Importing of old ModPacks

### DIFF
--- a/xivModdingFramework/Mods/FileTypes/TTMP.cs
+++ b/xivModdingFramework/Mods/FileTypes/TTMP.cs
@@ -330,8 +330,9 @@ namespace xivModdingFramework.Mods.FileTypes
                                 var line = streamReader.ReadLine();
                                 if (line.ToLower().Contains("version"))
                                 {
-                                    //mpInfo = JsonConvert.DeserializeObject<ModPackInfo>(line);
-                                    return null;
+                                    // Skip this line and read the next
+                                    line = streamReader.ReadLine();
+                                    modPackJsonList.Add(JsonConvert.DeserializeObject<OriginalModPackJson>(line));
                                 }
                                 else
                                 {


### PR DESCRIPTION
The implementation for importing old modpacks was already near finished but returning null in the GetOriginalModPackJsonData function was causing crashes when the function was called. This small change skips the first line containing old unnecessary data and allows the old modpacks to be imported again.

Example of an old modpack's JSON data:
![image](https://user-images.githubusercontent.com/59175928/73136164-f5928800-404a-11ea-9190-c1883682913c.png)
