### PR TITLE
Add Trim() to gear name

### DIFF
--- a/xivModdingFramework/Items/Categories/Gear.cs
+++ b/xivModdingFramework/Items/Categories/Gear.cs
@@ -192,6 +192,7 @@ namespace xivModdingFramework.Items.Categories
                     br.BaseStream.Seek(gearNameOffset, SeekOrigin.Begin);
                     var nameString = Encoding.UTF8.GetString(br.ReadBytes(gearNameLength)).Replace("\0", "");
                     xivGear.Name = new string(nameString.Where(c => !char.IsControl(c)).ToArray());
+                    xivGear.Name = xivGear.Name.Trim();
 
                     lock (_gearLock)
                     {


### PR DESCRIPTION
Gear names are read from the item exd file and the Hyuran Tunic has a trailing space which causes issues when trying to export anything related to it. I've simply added a quick Trim() to solve this. 

![image](https://user-images.githubusercontent.com/59175928/73141810-8b003d00-4088-11ea-8ab5-a4468c93a456.png)
